### PR TITLE
CLI Fixes from Testing

### DIFF
--- a/stateless/cli/utils.py
+++ b/stateless/cli/utils.py
@@ -14,12 +14,9 @@ console = Console()
 def get_api_key_from_env():
     api_key = os.environ.get("STATELESS_API_KEY")
     if not api_key:
-        secho("API key not found in environment variables!", fg="red")
-        secho("Please set your API key in the environment variable STATELESS_API_KEY.", fg="red")
-        raise Exit(1)
-
+        secho("API key not found in environment variables! Please set your API key in the environment variable STATELESS_API_KEY.", fg="red")
+        return
     return api_key
-
 
 def make_request_with_api_key(
     method: str, url: str, data: str = None

--- a/stateless/main.py
+++ b/stateless/main.py
@@ -54,41 +54,30 @@ def main(
         # ASCII Art Logo
         secho(ascii_art, fg="green")
 
-        while True:
-            has_api_key = confirm("Do you have an API key to proceed?")
-
-            if not has_api_key:
-                secho("Redirecting to the API key registration page...", fg="red")
+        if not get_api_key_from_env():
+            if confirm("Do you need an API key to proceed?"):
+                secho("Redirecting to the API key registration page, afterwards please add it to your environment variables...", fg="red")
                 webbrowser.open("https://app.stateless.solutions")
-                secho("Waiting for a few seconds before asking again...", fg="yellow")
-                time.sleep(5)
+        else:
+            response = make_request_with_api_key(
+                "GET", V1Routes.ACCOUNT_PROFILE
+            )
+            json_response = response.json()
+
+            if response.status_code == 200:
+                name: str = json_response["name"]
+                account_type: str = json_response["account_type"]
+                secho("You are logged in as: ", nl=False)
+                secho(f"{name} [{account_type.capitalize()}]", fg="yellow")
+                secho(
+                    "Explore our commands by running `stateless-cli --help`",
+                    fg="green",
+                )
             else:
-                api_key = get_api_key_from_env()
-                if not api_key:
-                    return
-                else:
-                    response = make_request_with_api_key(
-                        "GET", V1Routes.ACCOUNT_PROFILE
-                    )
-                    json_response = response.json()
-
-                    if response.status_code == 200:
-                        name: str = json_response["name"]
-                        account_type: str = json_response["account_type"]
-                        secho("You are logged in as: ", nl=False)
-                        secho(f"{name} [{account_type.capitalize()}]", fg="yellow")
-                        secho(
-                            "Explore our commands by running `stateless-cli --help`",
-                            fg="green",
-                        )
-                    else:
-                        secho(
-                            f"Error getting account profile: {json_response['detail']}",
-                            fg="red",
-                        )
-
-                break
-
+                secho(
+                    f"Error getting account profile: {json_response['detail']}",
+                    fg="red",
+                )
 
 def _main():
     app()


### PR DESCRIPTION
simplify onboarding, and remove while loop wait for env var (wont work if added outside of child python proc) Fix entrypoints list, and safeguard against a new provider not having any offerings, otherwise they would have further issues if someone already has the api key in the environment vars, dont prompt them if they have one to proceed